### PR TITLE
Fix broken links in Language Reference

### DIFF
--- a/src/data/docs/language-reference/expressions.md
+++ b/src/data/docs/language-reference/expressions.md
@@ -54,7 +54,7 @@ Prefix function application:
 
 * Binds more tightly than infix operators. So `f x + g y` is the same as `(f x) + (g y)`.
 * Binds less tightly than keywords that introduce [blocks](/docs/language-reference/blocks). So `f let x` is the same as `f (let x)` and `f if b then p else q` is the same as `f (if b then p else q)`
-* Binds less tightly than `'` and `!` (see [delayed computations](docs/language-reference/expressions/#delayed-computations)), so `'f x y` is the same as `(_ -> f) x y` and `!f x y` is the same as `f () x y`.
+* Binds less tightly than `'` and `!` (see [delayed computations](#delayed-computations)), so `'f x y` is the same as `(_ -> f) x y` and `!f x y` is the same as `f () x y`.
 
 ## Boolean expressions
 A Boolean expression has type `Boolean` which has two values, `true` and `false`.
@@ -67,7 +67,7 @@ Evaluation of conditional expressions is non-strict. The evaluation semantics of
 * If `c` evaluates to `true`, the expression `t`  is evaluated and `f` remains unevaluated. The whole expression reduces to the value of `t`.
 * If `c` evaluates to `false`, the expression `f` is evaluated and `t` remains unevaluated. The whole expression reduces to the value of `f`.
 
-The keywords `if`, `then`, and `else` each introduce a [Block](docs/language-reference/expressions/blocks)  as follows:
+The keywords `if`, `then`, and `else` each introduce a [Block](/docs/language-reference/blocks)  as follows:
 
 ``` unison
 if

--- a/src/data/docs/language-reference/type-declarations.md
+++ b/src/data/docs/language-reference/type-declarations.md
@@ -93,7 +93,7 @@ Point.x.modify : (Nat -> Nat) -> Point -> Point
 Point.x.set    : Nat -> Point -> Point
 Point.y        : Point -> Nat
 Point.y.modify : (Nat -> Nat) -> Point -> Point
-Point.y.set    : Nat -> Point -> Poin
+Point.y.set    : Nat -> Point -> Point
 ```
 
 > 👉 Note that `set` and `modify` are returning new, modified copies of the input record - there's no mutation of values in Unison.

--- a/src/data/docs/language-reference/types.md
+++ b/src/data/docs/language-reference/types.md
@@ -26,7 +26,7 @@ A full treatise on types is beyond the scope of this document. In short, types h
 
 * `[1,2,3]` is well typed, since lists require all elements to be of the same type.
 * `42 + "hello"` is not well typed, since the type of `+` disallows adding numbers and text together.
-* `printLine "Hello, World!"` is well typed in some contexts and not others. It's a type error for instance to use I/O functions where an `IO` [ability](/docs/language-reference/abilities-and-ability-handlers) is not provided.
+* `printLine "Hello, World!"` is well typed in some contexts and not others. It's a type error for instance to use I/O functions where an `IO` [ability](/docs/language-reference/abilities) is not provided.
 
 Types are of the following general forms.
 


### PR DESCRIPTION
No promises that I caught all of them, these are just the view I stumbled upon when reading the language reference.