### PR TITLE
Add missing link reference

### DIFF
--- a/src/data/docs/tour/hello-ucm.md
+++ b/src/data/docs/tour/hello-ucm.md
@@ -96,6 +96,8 @@ So rename and move things around as much as you want. Don't worry about picking 
 
 > 🤓 If you're curious to learn about the guts of the Unison codebase format, you can check out the [v1 codebase format specification][repoformat].
 
+[repoformat]: https://github.com/unisonweb/unison/blob/master/docs/repoformats/v1-DRAFT.markdown
+
 Use `undo` to back up a step.  (We don't have a `redo` yet, though).
 
 ```


### PR DESCRIPTION
I noticed that the link wasn't rendering properly while reading through. 

![image](https://user-images.githubusercontent.com/408753/67153137-f8464a00-f2b1-11e9-9c37-b8a1da704198.png)

https://www.unisonweb.org/docs/tour/hello-ucm