### PR TITLE
Update to use infix boolean operators and update `next` link

### DIFF
--- a/src/data/docs/language-reference/expressions.md
+++ b/src/data/docs/language-reference/expressions.md
@@ -79,13 +79,13 @@ else
 ```
 
 ### Boolean conjunction and disjunction
-A _Boolean conjunction expression_ is a `Boolean` expression of the form `and a b` where `a` and `b` are `Boolean` expressions. Note that `and` is not a function, but built-in syntax.
+A _Boolean conjunction expression_ is a `Boolean` expression of the form `a && b` where `a` and `b` are `Boolean` expressions. Note that `&&` is not a function, but built-in syntax.
 
-The evaluation semantics of `and a b` are equivalent to `if a then b else false`.
+The evaluation semantics of `a && b` are equivalent to `if a then b else false`.
 
-A _Boolean disjunction expression_ is a `Boolean` expression of the form `or a b` where `a` and `b` are `Boolean` expressions. Note that `or` is not a function, but built-in syntax.
+A _Boolean disjunction expression_ is a `Boolean` expression of the form `a || b` where `a` and `b` are `Boolean` expressions. Note that `||` is not a function, but built-in syntax.
 
-The evaluation semantics of `or a b` are equivalent to `if a then true else b`.
+The evaluation semantics of `a || b` are equivalent to `if a then true else b`.
 
 ## Delayed computations
 
@@ -122,4 +122,4 @@ Additional `'` and `!` combine in the obvious way:
 
 You can of course use parentheses to precisely control how `'` and `!` get applied.
 
-__Next:__ [Types](/docs/language-reference/types)
+__Next:__ [Types](/docs/language-reference/hashes)

--- a/src/data/docs/language-reference/expressions.md
+++ b/src/data/docs/language-reference/expressions.md
@@ -122,4 +122,4 @@ Additional `'` and `!` combine in the obvious way:
 
 You can of course use parentheses to precisely control how `'` and `!` get applied.
 
-__Next:__ [Types](/docs/language-reference/hashes)
+__Next:__ [Hashes](/docs/language-reference/hashes)

--- a/src/data/docs/language-reference/hashes.md
+++ b/src/data/docs/language-reference/hashes.md
@@ -20,3 +20,4 @@ A term, type, data constructor, or ability constructor may be unambiguously refe
 
 ## Short hashes
 A hash literal may use a prefix of the base32Hex encoded SHA3 digest instead of the whole thing. For example the programmer may use a short hash like `#r1mtr0` instead of the much longer 104-character representation of the full 512-bit hash. If the short hash is long enough to be unambiguous given the [environment](/docs/language-reference/name-resolution), Unison will substitute the full hash at compile time. When rendering code as text, Unison may calculate the minimum disambiguating hash length before rendering a hash.
+__Next:__ [Types](/docs/language-reference/types)


### PR DESCRIPTION
Update the documentation to use the infix boolean operator notion.
And fix the link which points the next page. I guess the `hash` page was added later so nothing linked to it and itself didn't link to the next article