### PR TITLE
`ucm init` instead of `ucm` in quickstart

### DIFF
--- a/src/data/docs/quickstart.md
+++ b/src/data/docs/quickstart.md
@@ -19,7 +19,7 @@ When Unison is further along and ready for more general availability we'll just 
 
 ## Step 2: Create your Unison codebase
 
-Create a new directory, `unisoncode` (or any name you choose), then run the `ucm` binary from within that directory. You'll see a note about "No codebase exists here so I'm initializing one..." and a welcome screen.
+Create a new directory, `unisoncode` (or any name you choose), then run the `ucm init` binary from within that directory. You'll see a note about "No codebase exists here so I'm initializing one..." and a welcome screen.
 <script id="asciicast-dvwP7oXFwf0qwQWds1ShFXMP8" src="https://asciinema.org/a/dvwP7oXFwf0qwQWds1ShFXMP8.js" data-speed="1.4" data-cols="65" async></script>
 
 ## Step 3: Fetch and run a distributed mergesort example


### PR DESCRIPTION
When I was following the quickstart, when I ran `ucm` in `Step 2: Create your Unison codebase`, then I got the output:
```
$ ucm
  ⚠️
  No codebase exists in /my-path/homedir Run `ucm init` to create one, then try again!
```
So, I ran `ucm init` as it suggested:
```
$ ucm init
  ⚠️
  Initializing a new codebase in: /my-path/homedir
```
I could be confused, but figured I'd throw up this PR if that's the correct thing to do, thanks! Let me know if you have any questions, I'm new to Unison.