### PR TITLE
Fix for #42

### DIFF
--- a/src/data/docs/language-reference/type-declarations.md
+++ b/src/data/docs/language-reference/type-declarations.md
@@ -5,7 +5,7 @@ description: placeholder
 
 # User-defined data types
 
-A user-defined data type is introduced with the `type` keyword.
+A user-defined data type is introduced with the `type` keyword. (See [Types](/docs/language-reference/types) for an informal description of Unison's type system.)
 
 For example:
 
@@ -15,7 +15,7 @@ type Optional a = None | Some a
 
 The `=` sign splits the definition into a _left-hand side_ and a _right-hand side_, much like term definitions.
 
-The left-hand side is the data type being defined. It gives a name for the data type and declares a new _type constructor_ with that name (here it’s named `Optional`), followed by names for any type arguments (here there is one and it’s called `a`). These names are bound as type variables in the right-hand side. The right-hand side may also refer to the name given to the type in the left-hand side, in which case it is a recursive type declaration. Note that the fully saturated type construction `Optional Nat` is a type, whereas `Optional` by itself is a type constructor, not a type (it requires a type argument in order to construct a type).
+The left-hand side is the data type being defined. It gives a name for the data type and declares a new [_type constructor_](/docs/language-reference/types#type-constructors) with that name (here it’s named `Optional`), followed by names for any type arguments (here there is one and it’s called `a`). These names are bound as type variables in the right-hand side. The right-hand side may also refer to the name given to the type in the left-hand side, in which case it is a recursive type declaration. Note that the fully saturated type construction `Optional Nat` is a type, whereas `Optional` by itself is a type constructor, not a type (it requires a type argument in order to construct a type).
 
 The right-hand side consists of zero or more data constructors separated by `|`. These are _data constructors_ for the type, or ways in which values of the type can be constructed. Each case declares a name for a data constructor (here the data constructors are `None` and `Some`), followed by the **types** of the arguments to the constructor.
 

--- a/src/data/docs/language-reference/types.md
+++ b/src/data/docs/language-reference/types.md
@@ -126,7 +126,7 @@ Unison has the following built-in type constructors.
 * `.base.Request` is the constructor of requests for abilities. A type `Request A T` is the type of values received by ability handlers for the ability `A` where current continuation requires a value of type `T`.
 
 ## User-defined types
-New types can be declared as described in detail in the [User-defined types](/docs/language-reference/type-declarations) section. These include ordinary [data types](/docs/language-reference/type-declarations), [unique types](/docs/language-reference/type-declarations#unique-types), and [record types](/docs/language-references/type-declarations#record-types). A type declaration introduces a _type_, a corresponding _type constructor_, one or more _data constructors_ that (collectively) construct all possible values of the type, and (in the case of record types) accessors for the named arguments of the type's single data constructor.
+New types can be declared as described in detail in the [User-defined types](/docs/language-reference/type-declarations) section. These include ordinary [data types](/docs/language-reference/type-declarations), [unique types](/docs/language-reference/type-declarations#unique-types), and [record types](/docs/language-reference/type-declarations#record-types). A type declaration introduces a _type_, a corresponding _type constructor_, one or more _data constructors_ that (collectively) construct all possible values of the type, and (in the case of record types) accessors for the named arguments of the type's single data constructor.
 
 __Next:__ [Abilities and ability handlers](/docs/language-reference/abilities)
 

--- a/src/data/docs/language-reference/types.md
+++ b/src/data/docs/language-reference/types.md
@@ -4,7 +4,7 @@ description: placeholder
 ---
 
 # Unison types
-This section describes informally the structure of types in Unison.
+This section describes informally the structure of types in Unison. See also the section titled [User-defined types](/docs/language-reference/type-declarations) for detailed information on how to define new data types.
 
 Formally, Unison’s type system is an implementation of the system described by Joshua Dunfield and Neelakantan R. Krishnaswami in their 2013 paper [Complete and Easy Bidirectional Typechecking for Higher-Rank Polymorphism](https://arxiv.org/abs/1306.6032).
 
@@ -124,6 +124,9 @@ Unison has the following built-in type constructors.
 *  `base.Tuple` is the constructor of tuple types. See [tuple types](#tuple-types) for details on tuples.
 * `.base.List` is the constructor of list types. A type `List T` is the type of arbitrary-length sequences of values of type `T`. The type `[T]` is an alias for `List T`.
 * `.base.Request` is the constructor of requests for abilities. A type `Request A T` is the type of values received by ability handlers for the ability `A` where current continuation requires a value of type `T`.
+
+## User-defined types
+New types can be declared as described in detail in the [User-defined types](/docs/language-reference/type-declarations) section. These include ordinary [data types](/docs/language-reference/type-declarations), [unique types](/docs/language-reference/type-declarations#unique-types), and [record types](/docs/language-references/type-declarations#record-types). A type declaration introduces a _type_, a corresponding _type constructor_, one or more _data constructors_ that (collectively) construct all possible values of the type, and (in the case of record types) accessors for the named arguments of the type's single data constructor.
 
 __Next:__ [Abilities and ability handlers](/docs/language-reference/abilities)
 


### PR DESCRIPTION
Here's a quick pass. I think the docs collectively do a good job of distinguishing types from type declarations, and I've tried to maintain that distinction in these changes (hopefully without being confusing).

I'm not sure how to test the hyperlinks. They act broken when I view the markdown on github, but so do links that are unchanged. :/