### PR TITLE
improve language reference subsection on ability handlers

### DIFF
--- a/src/data/docs/language-reference/README.md
+++ b/src/data/docs/language-reference/README.md
@@ -914,7 +914,7 @@ A constructor `{A} T` for some ability `A` and some type `T`  (or a function whi
 handle e with h
 ```
 
-This expression gives `e` access to abilities handled by the function `h`. If `h` has type `Request A T1 -> T2` and the expression `e` has type `{A} T1`, then `handle e with h` will have type `T2`. The type constructor `Request` is a special builtin provided by Unison which will pass arguments of type `Request A T` to a handler for the ability `A`. Note that `h` _must_ accept an argument of type `Request A T` if it is used to handle `e` of type `{A} T1`.
+This expression gives `e` access to abilities handled by the function `h`. Specifically, if `e` has type `{A} T` and `h` has type `Request A T -> R`, then `handle e with h` has type `R`. The type constructor `Request` is a special builtin provided by Unison which will pass arguments of type `Request A T` to a handler for the ability `A`. Note that `h` _must_ accept an argument of type `Request A T` to handle `e` of type `{A} T`&mdash;ultimately, a type error will result if an ability is required in a scope where it is not provided by an enclosing handle expression.
 
 The examples in the next section should help clarify how ability handlers work.
 


### PR DESCRIPTION
Minor improvements and corrections, including:
* use `{A} T` consistently, instead of sometimes using `{A} T1`
* correct an instance where `{A} T1` was used when `{A} T` should have been
* clarify typing rules, without being overly formal or getting into handler stacking