### PR TITLE
add documentation on `run` command

### DIFF
--- a/src/data/docs/abilities.md
+++ b/src/data/docs/abilities.md
@@ -90,6 +90,8 @@ If you _don't_ want this inference, just add ability brackets to the arrow (like
 
 [Delayed computations](#delayed-computations) are treated just like functions by Unison and can also have ability requirements. For instance, `'(printLine "Hi!")` will have the type `'{IO} ()`. See [this appendix](#delayed-computations) for more on this.
 
+> 🏁  In case you're wondering how to run a program that requires the `IO` ability, you can use the `run` command in `ucm`. For example, `run myProgram` will evaluate `!myProgram`, where `myProgram` identifies a term of type `'{IO} ()` (or, equivalently, `() ->{IO} ()`) in the codebase or in the most recently typechecked scratch file.  🏎
+
 ### Ability polymorphism
 
 Often, higher-order functions (like `List.map`) don't care whether their input functions require abilities or not. We say such functions _ability-polymorphic_ (or "ability-parametric"). For instance, here's the definition and signature of `List.map`, which applies a function to each element of a list:
@@ -218,7 +220,7 @@ Stream.toList stream =
 What's happening here?
 
 * Here, the recursive function `h` is the handler. Its first argument `[a]` is an accumulated list of the values emitted so far. Its second argument is the requested operation, which it inspects before resuming. Handlers will frequently be recursive functions like this where the state of the handler is represented with the first argument(s) and request is the final parameter to the function. We'll explain the `cases ...` part in a minute.
-* `handle !stream with ... h []` says to start evaluating the `stream` computation and if it makes any requests, pass them to the handler `h []`".
+* `handle !stream with h []` says to start evaluating the `stream` computation and if it makes any requests, pass them to the handler `h []`.
   * `h []` is just a partial application of the function `h`, `h []` will have type `Request {Stream a} () -> [a]`.
 * Let's look now at the body of `h`, the `cases ...` part:
   * In the line `{Stream.emit e -> resume}`, think of `resume` as a function which represents "the rest of the computation"  (or _continuation_) after the point in the code where the request was made. The name `resume` here isn't special, we could name it `k`, `frobnicate`, or even `_` if we planned to ignore the continuation and never resume the computation.

--- a/src/data/docs/commands.md
+++ b/src/data/docs/commands.md
@@ -162,6 +162,26 @@ The first argument to `pull` is any [Git URL](#git-url) that identifies the name
 
 Use `quit` (or `exit` or `:q`) to terminate UCM.
 
+## `run`
+
+The `run` command is used to evaluate terms that require the `IO` ability within `ucm`.  A program that performs `IO` cannot be evaluated in a watch expression but _can_ be executed with `run`.
+
+Formally, `run myProgram` will force a [delayed computation](/docs/language-reference#delayed-computations) `myProgram` of type `'{IO} ()`, evaluating `!myProgram` in a context where the `IO` ability is provided by the Unison runtime. The argument (e.g., `myProgram`) must be defined in the codebase or in the most recently typechecked scratch file.
+
+Here's an example:
+
+```unison
+greet : Text ->{IO} ()
+greet name = printLine ("Hello, " ++ name ++ "!")
+
+helloWorld : '{IO} ()
+helloWorld = '(greet "World")
+```
+
+```ucm
+.> run helloWorld
+```
+
 ## `undo`
 
 Use `undo` to revert the most recent change to the codebase. Some commands result in multiple steps in the history. You can use the [`reflog`](#reflog) and [`reset-root`](#reset-root) commands to move around history more reliably.
@@ -170,7 +190,7 @@ Use `undo` to revert the most recent change to the codebase. Some commands resul
 
 #### How do I redo a change after an `undo`?
 
-Use [the `reflog` command](#reflog) to jump to the point in history just before the `undo`. 
+Use [the `reflog` command](#reflog) to jump to the point in history just before the `undo`.
 
 > 😕 We'd like this to be a nicer experience. A `redo` command sounds nice, but it's not implemented yet!
 

--- a/src/data/transcripts/abilities.md
+++ b/src/data/transcripts/abilities.md
@@ -57,6 +57,8 @@ If you _don't_ want this inference, just add ability brackets to the arrow (like
 
 [Delayed computations](#delayed-computations) are treated just like functions by Unison and can also have ability requirements. For instance, `'(printLine "Hi!")` will have the type `'{IO} ()`. See [this appendix](#delayed-computations) for more on this.
 
+> 🏁  In case you're wondering how to run a program that requires the `IO` ability, you can use the `run` command in `ucm`. For example, `run myProgram` will evaluate `!myProgram`, where `myProgram` identifies a term of type `'{IO} ()` (or, equivalently, `() ->{IO} ()`) in the codebase or in the most recently typechecked scratch file.  🏎
+
 ### Ability polymorphism
 
 Often, higher-order functions (like `List.map`) don't care whether their input functions require abilities or not. We say such functions _ability-polymorphic_ (or "ability-parametric"). For instance, here's the definition and signature of `List.map`, which applies a function to each element of a list:
@@ -138,7 +140,7 @@ Stream.toList stream =
 What's happening here?
 
 * Here, the recursive function `h` is the handler. Its first argument `[a]` is an accumulated list of the values emitted so far. Its second argument is the requested operation, which it inspects before resuming. Handlers will frequently be recursive functions like this where the state of the handler is represented with the first argument(s) and request is the final parameter to the function. We'll explain the `cases ...` part in a minute.
-* `handle !stream with ... h []` says to start evaluating the `stream` computation and if it makes any requests, pass them to the handler `h []`".
+* `handle !stream with h []` says to start evaluating the `stream` computation and if it makes any requests, pass them to the handler `h []`.
   * `h []` is just a partial application of the function `h`, `h []` will have type `Request {Stream a} () -> [a]`.
 * Let's look now at the body of `h`, the `cases ...` part:
   * In the line `{Stream.emit e -> resume}`, think of `resume` as a function which represents "the rest of the computation"  (or _continuation_) after the point in the code where the request was made. The name `resume` here isn't special, we could name it `k`, `frobnicate`, or even `_` if we planned to ignore the continuation and never resume the computation.


### PR DESCRIPTION
This PR updates the command reference and the abilities tutorial with documentation on running programs that perform `IO`.