### PR TITLE
fix random typo in a code block

### DIFF
--- a/src/data/docs/testing.md
+++ b/src/data/docs/testing.md
@@ -270,8 +270,7 @@ Doing a breadth-first enumeration is the right move because as we build up more 
 
 There are two other ways of combining generators. One is `pick`, which fairly samples from multiple generators in a breadth first manner:
 
-```
-Haskell
+```unison
 pick : ['{Gen} a] -> '{Gen} a
 
 ```


### PR DESCRIPTION
this one had:

```
>>>
Haskell
```

which probably used to be 

```
>>> Haskell
```

and was left out of a mass search and replace to replace `>>> Haskell` with `>>> unison`