### PR TITLE
Add FAQ to cover running out of inotify watches on Linux

### DIFF
--- a/src/data/docs/faq.md
+++ b/src/data/docs/faq.md
@@ -54,6 +54,22 @@ sudo apt-get install libtinfo5
 
 (This issue is tracked under [#602](https://github.com/unisonweb/unison/issues/682).)
 
+### When I save my scratch file, `ucm` doesn't react
+
+On Linux, this can happen if your system has run out of 'inotify watches'.  (Backup applications often use a lot of these.)
+
+You can see if this is the case by running `tail -f <file>` on a file of your choice, and looking out for the following output.
+```
+tail: inotify cannot be used, reverting to polling: Too many open files
+```
+
+If so you can up the limit by doing
+```
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+```
+
+Search stackoverflow for more tips if that command doesn't work for you.
+
 ## Language
 
 ### Does Unison have Haskell-style type classes?


### PR DESCRIPTION
My backup application eats a lot of inotify watches apparently, so a couple of times I've started `ucm` and found it doesn't react when I save scratch files.

This PR adds an FAQ, for what that's worth.

I fear this is the sort of thing someone would hit when first trying unison, and then immediately give up without saying anything.  I'll raise an issue in the unison repo about getting an error message in this case.  