### PR TITLE
Change base to :.releases.M1k base

### DIFF
--- a/src/data/docs/tour/README.md
+++ b/src/data/docs/tour/README.md
@@ -57,7 +57,7 @@ If you haven't already worked through the [quickstart guide][quickstart], let's 
 ---
 title: ucm
 ---
-.> pull https://github.com/unisonweb/base .base
+.> pull https://github.com/unisonweb/base:.releases._M1k base
 ```
 
 This command uses git behind the scenes to sync new definitions from the remote Unison codebase to the local codebase.


### PR DESCRIPTION
M1k moved libraries to `trunk` and `releases`, and so M1k need its `base.trunk` to be aliased to `base`.