### PR TITLE
Explain the pull command namespacing in the tour

### DIFF
--- a/src/data/docs/tour/README.md
+++ b/src/data/docs/tour/README.md
@@ -60,7 +60,9 @@ title: ucm
 .> pull https://github.com/unisonweb/base:.releases._M1k base
 ```
 
-This command uses git behind the scenes to sync new definitions from the remote Unison codebase to the local codebase.
+This command uses Git behind the scenes to sync new definitions from the remote Unison codebase to the local codebase.
+
+> 📁 Here the command is performed in the top-level namespace, represented by `.`. The prompt shows us which namespace we are currently in. If we were in a different namespace, we would need to change the `pull` command from using the _relative path_ `base` to the _absolute path_ `.base`. 
 
 Because of the append-only nature of the codebase format, we can cache all sorts of interesting information about definitions in the codebase and _never have to worry about cache invalidation_. For instance, Unison is a statically-typed language and we know the type of all definitions in the codebase--the codebase is always in a well-typed state. So one thing that's useful and easy to maintain is an index that lets us search for definitions in the codebase by their type. Try out the following commands (new syntax is explained below):
 


### PR DESCRIPTION
This change adds a small description to the tour about how namespacing
works with the `pull` command. This will help avoid pulls into the wrong
place, and help readers visualize namespaces as a hierarchy that can
be referred to both absolutely and relatively.