### PR TITLE
Sync

### DIFF
--- a/src/data/docs/language-reference/README.md
+++ b/src/data/docs/language-reference/README.md
@@ -901,7 +901,7 @@ New types can be declared as described in detail in the [User-defined types](#us
 Unison provides a convenient feature called _abilities_ which lets you use the same ordinary Unison syntax for programs that do (asynchronous) I/O, stream processing, exception handling, parsing, distributed computation, and lots more.  Unison's system of abilities (often called "algebraic effects" in the literature) is based on [the Frank language by Sam Lindley, Conor McBride, and Craig McLaughlin](https://arxiv.org/pdf/1611.09259.pdf). Unison diverges slightly from the scheme detailed in this paper. In particular:
 
 * Unison's ability polymorphism is provided by ordinary polymorphic types, and a Unison type with an empty ability set explicitly disallows any abilities. In Frank, the empty ability set implies an ability-polymorphic type.
-* Unison doesn't overload function application syntax to do ability handling; instead it has a separate [`handle` construct](#handle-blocks) for this purpose.
+* Unison doesn't overload function application syntax to do ability handling; instead it has a separate [`handle` construct](#ability-handlers) for this purpose.
 
 ### Abilities in function types
 

--- a/src/data/docs/quickstart.md
+++ b/src/data/docs/quickstart.md
@@ -31,7 +31,7 @@ Run `ucm init` to initialize a Unison codebase in `$HOME/.unison`. This is where
 Launch `ucm` again, then from the `.>` prompt, do:
 
 ```ucm
-pull https://github.com/unisonweb/base:.releases._M1l base
+pull https://github.com/unisonweb/base:.releases._latest base
 ```
 
 You'll see some output from `git` in the background, and once that's done you'll see a big list of definitions that the `pull` added. Press `q` to exit the list of definitions.

--- a/src/data/docs/tour/README.md
+++ b/src/data/docs/tour/README.md
@@ -57,7 +57,7 @@ If you haven't already worked through the [quickstart guide][quickstart], let's 
 ---
 title: ucm
 ---
-.> pull https://github.com/unisonweb/base:.releases._M1l base
+.> pull https://github.com/unisonweb/base:.releases._latest base
 ```
 
 This command uses Git behind the scenes to sync new definitions from the remote Unison codebase to the local codebase.


### PR DESCRIPTION
Some tweaks to the suggested release cutting process, and updated quickstart and tour to refer to `_latest` of base rather than a specific named version.