### PR TITLE
Replace references to `master` with `trunk`

### DIFF
--- a/src/data/blog/posts/2019-01-09-new-years-update/index.md
+++ b/src/data/blog/posts/2019-01-09-new-years-update/index.md
@@ -76,7 +76,7 @@ Under the bonnet, Unison creates a directory called `.unison` which contains the
 
 Since everything is indexed by hash, you'll never actually change any file, so Git merge conflicts should never happen.
 
-See [the Codebase Editor design document](https://github.com/unisonweb/unison/blob/master/docs/codebase-editor-design.markdown) for more information.
+See [the Codebase Editor design document](https://github.com/unisonweb/unison/blob/trunk/docs/codebase-editor-design.markdown) for more information.
 
 ### More features
 

--- a/src/data/blog/posts/2020-03-30-benefit-corp-report/index.md
+++ b/src/data/blog/posts/2020-03-30-benefit-corp-report/index.md
@@ -8,7 +8,7 @@ categories: ["announcements"]
 featuredImage: /media/thing11.svg
 ---
 
-Unison Computing is a [public benefit corp](https://en.wikipedia.org/wiki/Public-benefit_corporation) (PBC), cofounded by Paul Chiusano, Rúnar Bjarnason, and Arya Irani. We work alongside other [amazing open source contributors](https://github.com/unisonweb/unison/blob/master/CONTRIBUTORS.markdown) on the Unison language. 💜 This post talks about why Unison Computing is a PBC and also includes our first annual report.
+Unison Computing is a [public benefit corp](https://en.wikipedia.org/wiki/Public-benefit_corporation) (PBC), cofounded by Paul Chiusano, Rúnar Bjarnason, and Arya Irani. We work alongside other [amazing open source contributors](https://github.com/unisonweb/unison/blob/trunk/CONTRIBUTORS.markdown) on the Unison language. 💜 This post talks about why Unison Computing is a PBC and also includes our first annual report.
 
 > 📕 If you're new to the Unison language and would like an overview of the project and its core ideas, we recommend this [40 minute Strange Loop talk](https://www.youtube.com/watch?v=gCWtkvDQ2ZI).
 

--- a/src/data/docs/faq.md
+++ b/src/data/docs/faq.md
@@ -149,7 +149,7 @@ This area of Unison has had plenty of thought and research, but isn't built yet.
 
 - Paul's [Scale By The Bay 2018 talk](https://www.youtube.com/watch?v=v7L-5AQQkbM), from about 8 minutes in.
 - The 2015 [blog post](https://github.com/unisonweb/oldblog/blob/master/_posts/2015-06-02-distributed-evaluation.markdown) on distributed evaluation.
-- The current [API sketch](https://github.com/unisonweb/unison/blob/master/docs/distributed-programming-rfc.markdown).
+- The current [API sketch](https://github.com/unisonweb/unison/blob/trunk/docs/distributed-programming-rfc.markdown).
 
 ## Codebase model
 

--- a/src/data/docs/tour/README.md
+++ b/src/data/docs/tour/README.md
@@ -13,7 +13,7 @@ If you want to follow along with this document (highly recommended), this guide 
 
 The source for this document is [on GitHub][on-github]. Feedback and improvements are most welcome!
 
-[repoformat]: https://github.com/unisonweb/unison/blob/master/docs/repoformats/v1-DRAFT.markdown
+[repoformat]: https://github.com/unisonweb/unison/blob/trunk/docs/repoformats/v1-DRAFT.markdown
 [on-github]: https://github.com/unisonweb/unisonweb-org/edit/master/src/data/docs/tour/README.md
 [roadmap]: roadmap.html
 [quickstart]: /docs/quickstart
@@ -133,7 +133,7 @@ So rename and move things around as much as you want. Don't worry about picking 
 
 > 🤓 If you're curious to learn about the guts of the Unison codebase format, you can check out the [v1 codebase format specification][repoformat].
 
-[repoformat]: https://github.com/unisonweb/unison/blob/master/docs/repoformats/v1-DRAFT.markdown
+[repoformat]: https://github.com/unisonweb/unison/blob/trunk/docs/repoformats/v1-DRAFT.markdown
 
 Use `undo` to back up a step.  (We don't have a `redo` yet, though).
 

--- a/src/data/layouts/partials/site-footer.yml
+++ b/src/data/layouts/partials/site-footer.yml
@@ -1,2 +1,2 @@
 meta: |
-  &copy; 2019 [Unison Computing, a public benefit corp](/unisoncomputing) and [contributors](https://github.com/unisonweb/unison/blob/master/CONTRIBUTORS.markdown) &bull; [this site on GitHub](https://github.com/unisonweb/unisonweb-org/tree/master/src/data/docs)
+  &copy; 2019 [Unison Computing, a public benefit corp](/unisoncomputing) and [contributors](https://github.com/unisonweb/unison/blob/trunk/CONTRIBUTORS.markdown) &bull; [this site on GitHub](https://github.com/unisonweb/unisonweb-org/tree/master/src/data/docs)

--- a/src/data/supplemental-pages/unisoncomputing.md
+++ b/src/data/supplemental-pages/unisoncomputing.md
@@ -5,7 +5,7 @@ description: A little bit about the company behind Unison
 
 # About Unison Computing
 
-Unison Computing is a [public benefit corp](https://en.wikipedia.org/wiki/Public-benefit_corporation), cofounded by Paul Chiusano, Rúnar Bjarnason, and Arya Irani. We work alongside other [amazing open source contributors](https://github.com/unisonweb/unison/blob/master/CONTRIBUTORS.markdown) on the Unison language. 💜
+Unison Computing is a [public benefit corp](https://en.wikipedia.org/wiki/Public-benefit_corporation), cofounded by Paul Chiusano, Rúnar Bjarnason, and Arya Irani. We work alongside other [amazing open source contributors](https://github.com/unisonweb/unison/blob/trunk/CONTRIBUTORS.markdown) on the Unison language. 💜
 
 Our overall mission: advance what's possible with software and work to make software creation simpler and more accessible to all. The company does research and development into new, free, open source software technologies like Unison, and builds useful products and services (like [the Unison Cloud Platform](http://unison.cloud)) to help capitalize this mission. 
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,3 @@
 # Redirects from what the browser requests to what we serve
-/docs/transcripts https://github.com/unisonweb/unison/blob/master/unison-src/transcripts/hello.md
+/docs/transcripts https://github.com/unisonweb/unison/blob/trunk/unison-src/transcripts/hello.md
 /slack       https://join.slack.com/t/unisonlanguage/shared_invite/enQtNzAyMTQ4ODA0MDM4LWYxZTNkMGUxMDEzNTg3NTMxNjMxOGM2Zjg4ODFjM2RhNGY0OGU2NTMzYmQ1YWIwN2Y0YTc1NjQ1NjgzYzEzOWI


### PR DESCRIPTION
Looks like the main branch name changed lately for https://github.com/unisonweb/unison. This patch fixes the broken links.