### PR TITLE
Fix vim-plug line for unison vim support

### DIFF
--- a/src/data/docs/editor-setup.md
+++ b/src/data/docs/editor-setup.md
@@ -17,7 +17,7 @@ Using [vim-plug][vimplug]:
 1. Install [vim-plug][vimplug] if you haven't already.
 2. Add the following to your .vimrc:
 
-        Plug 'unisonweb/unison', { 'rtp': 'editor-support/vim' }
+        Plug 'unisonweb/unison', { 'branch': 'trunk', 'rtp': 'editor-support/vim' }
 
 3. Issue the vim command `:PlugInstall`.
 


### PR DESCRIPTION
Small doc fix! There's no `master` branch in https://github.com/unisonweb/unison -- use `trunk` instead.

