### PR TITLE
fix Stream.filter example (again)

### DIFF
--- a/src/data/docs/abilities.md
+++ b/src/data/docs/abilities.md
@@ -573,7 +573,8 @@ Stream.filter f s =
   go _ =
     a = ask
     if f a then emit a
-    else !go
+    else ()
+    !go
   Stream.pipe s go
 
 Stream.map f s =

--- a/src/data/transcripts/abilities.md
+++ b/src/data/transcripts/abilities.md
@@ -417,7 +417,8 @@ Stream.filter f s =
   go _ =
     a = ask
     if f a then emit a
-    else !go
+    else ()
+    !go
   Stream.pipe s go
 
 Stream.map f s =


### PR DESCRIPTION
This PR fixes the Stream.filter example in the abilities tutorial, in both the transcript file and the generated markdown.