### PR TITLE
Fix `#bostonunisondevs` slack link in `/community`

### DIFF
--- a/src/data/supplemental-pages/community.md
+++ b/src/data/supplemental-pages/community.md
@@ -9,7 +9,7 @@ Welcome! Here are some of the places where folks discuss Unison:
 
 * The [Unison Slack](/slack) is pretty active.  (Please join with your full name so we know who we’re talking to, and to reduce the chance of collision.)
 * There's a [Boston Unison meetup group](https://www.meetup.com/Boston-Unison/) that meets semi-regularly.  
-* There's a [Boston Unison developers group](https://github.com/unisonweb/unison/wiki/Boston-Unison-Developers-meetup-notes) for folks in the Boston area interested in helping to build Unison. See the [#bostonunisondevs channel on Slack][slack] if you're in the Boston area and would like to participate.
+* There's a [Boston Unison developers group](https://github.com/unisonweb/unison/wiki/Boston-Unison-Developers-meetup-notes) for folks in the Boston area interested in helping to build Unison. See the [#bostonunisondevs channel on Slack](/slack) if you're in the Boston area and would like to participate.
 * Development happens on [the Unison GitHub repo](https://github.com/unisonweb/unison/), and there's also regular discussion in the [#contrib channel on Slack](/slack).
 
 We want these to be welcoming and enjoyable spaces for everyone. The [Code of Conduct](/code-of-conduct) outlines expectations for participants.


### PR DESCRIPTION
There was a malformed markdown link for the `#bostonunisondevs`. Fix it :)