### PR TITLE
Update ucm output for tests

### DIFF
--- a/src/data/docs/tour/README.md
+++ b/src/data/docs/tour/README.md
@@ -296,9 +296,9 @@ Save the file, and Unison comes back with:
 title: ucm
 show-numbers: false
 ---
-7 | test> square.tests.ex1 = check (square 4 == 16)
+8 | test> square.tests.ex1 = check (square 4 == 16)
 
-✅ Passed : Passed 1 tests.
+✅ Passed : Proved.
 ```
 
 Some syntax notes:
@@ -337,9 +337,9 @@ test> square.tests.prop1 =
 title: ucm
 show-numbers: false
 ---
-8 |   go _ = a = !nat
+11 |   go _ = a = !nat
 
-✅ Passed : Passed 100 tests. (cached)
+✅ Passed : Passed 100 tests.
 ```
 
 This will test our function with a bunch of different inputs.


### PR DESCRIPTION
The output for tests in the scratch file was a bit out of sync with reality:

- Non-property-based tests seem to print `Proved` now instead of `Passed 1 tests` (👍 on that, by the way.)
- Line numbers don't match either the doc or what I see in ucm.
- The result of the second test isn't `(cached)` the first time you try it. Seems like a further example showing when results are and aren't cached might be useful, but hinting at it at the wrong time is just confusing.

Trivial issues for sure but little disparities like this tend to distract from the substance of the doc.